### PR TITLE
Ackermann and control node adjusted for param passing

### DIFF
--- a/include/ap1/control/ackermann_controller.hpp
+++ b/include/ap1/control/ackermann_controller.hpp
@@ -18,10 +18,11 @@ class AckermannController
   public:
     struct Config
     {
-        double L;             // wheelbase in meters
-        double a_max;         // max longitudinal accleration (ms^-2)
-        double delta_max;     // max steering angle
-        double throttle_gain; // scales accel to throttle [-1, 1]
+        // Added default values for safety if config file fails to load
+        double L = 0.33;             // wheelbase in meters
+        double a_max = 2.0;          // max longitudinal accleration (ms^-2)
+        double delta_max = 0.5;      // max steering angle (~28 deg)
+        double throttle_gain = 1.0;  // scales accel to throttle [-1, 1]
     };
 
     explicit AckermannController(const Config &cfg);

--- a/include/ap1/control/control_node.hpp
+++ b/include/ap1/control/control_node.hpp
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include <string>
+#include <memory>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -33,7 +34,8 @@ class ControlNode : public rclcpp::Node
 
     // Controller
     std::unique_ptr<IController> controller_;
-    AckermannController ackermann_controller_;
+    // Unique_ptr used for delayd initialization. Allows construction after reading ros params
+    std::unique_ptr<AckermannController> ackermann_controller_;
 
     // Memory
     // half these types are very unnecessary, we should just have stampedfloat or
@@ -61,7 +63,7 @@ class ControlNode : public rclcpp::Node
     void control_loop_callback();
 
   public:
-    ControlNode(const std::string& cfg_path, float rate_hz = 60);
+    ControlNode(float rate_hz = 60);
 };
 } // namespace ap1::control
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,19 +10,10 @@ int main(int argc, char** argv)
     // init ros & ros logger
     rclcpp::init(argc, argv);
 
-    // get control node config path from args
-    std::string config_path = "";
-    if (argc > 1)
-    {
-        config_path = argv[1];
-    }
-    else
-    {
-        RCLCPP_ERROR(rclcpp::get_logger(LOGGER_NAME), "Usage: control_node <config.csv>");
-        return 1;
-    }
-
+    // Create node
     auto node = std::make_shared<ap1::control::ControlNode>(config_path);
+
+    // Spin node
     rclcpp::spin(node);
     rclcpp::shutdown();
     return 0;


### PR DESCRIPTION
# Merge Request / Pull Request

## Summary of Changes
Allows control to take in ros2 params for config path to load values used for ackermann controller. Uses delayed initalization, so defaults are loaded first and then overwritten based on config file. Otherwise, if file can't be laoded defaults are continued to be used

## Type of Change
- [ X ] Bug fix
- [ X ] New feature / task
- [ X ] Refactor
- [ ] Documentation

## Checklist (to be completed before review)
- [ X ] Code follows team standards (maybe)
- [ ] Tested locally
- [ X ] Tests added / updated if relevant (safety checks added no tests)
- [ ] Documentation updated if relevant
- [ ] CI / checks pass

## Related Issue / Task
- Closes #[issue_number] (if applicable)

## Notes / Additional Context
Any context for reviewers (limitations, known issues, future work)

